### PR TITLE
refactor: remove ESLint commands from lefthook and package.json

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,12 +2,12 @@ pre-commit:
   parallel: true
   follow: true
   commands:
-    lint:
-      glob: '*.{js,ts,jsx,tsx,json,md,html,css}'
-      run: |
-        echo "Running ESLint..."
-        npx eslint --fix {staged_files}
-        echo "ESLint completed ✅"
+    # lint:
+    #   glob: '*.{js,ts,jsx,tsx,json,md,html,css}'
+    #   run: |
+    #     echo "Running ESLint..."
+    #     npx eslint --fix {staged_files}
+    #     echo "ESLint completed ✅"
     format:
       glob: '*.{js,ts,jsx,tsx,json}'
       run: |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "lint": "eslint .",
     "start": "react-native start",
     "format": "prettier --write \"**/*.{js,ts,tsx,json}\"",
     "test": "jest"


### PR DESCRIPTION
This pull request includes changes to disable the linting process in the pre-commit hook and remove the `lint` script from `package.json`. These changes suggest that linting is no longer part of the automated workflow and must be handled manually or through other means.

Changes to linting configuration:

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL5-R10): Commented out the `lint` command in the pre-commit hook, effectively disabling automatic linting during commits.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8): Removed the `lint` script, which previously ran ESLint across the codebase.